### PR TITLE
Add description field to funnel schema

### DIFF
--- a/funnel.json
+++ b/funnel.json
@@ -20,6 +20,11 @@
     "mode": "NULLABLE"
   },
   {
+    "name": "description",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
     "name": "idfunnel",
     "type": "INTEGER",
     "mode": "NULLABLE"


### PR DESCRIPTION
### Description:
- Adds new `description` field to `funnel` schema.

Detected here: https://github.com/innocraft/matomo-cloud/actions/runs/25710882540
Merge after prod release (or later): https://github.com/innocraft/matomo-cloud/pull/4046