### PR TITLE
Cloud 3492 download schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,35 +31,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          release_flags=()
-          if [[ "$RELEASE_TAG" == *-* ]]; then
-            release_flags+=(--prerelease)
-          fi
-
           gh release create "$RELEASE_TAG" \
             dist/bigquery-json-schemas.zip \
             --title "$RELEASE_TAG" \
             --notes "Automated schema release for $RELEASE_TAG." \
             --verify-tag \
-            "${release_flags[@]}"
-
-      - name: Publish latest release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_TAG: ${{ github.ref_name }}
-        run: |
-          git tag --force latest "$GITHUB_SHA"
-          git push --force origin refs/tags/latest
-
-          if gh release view latest >/dev/null 2>&1; then
-            gh release upload latest dist/bigquery-json-schemas.zip --clobber
-            gh release edit latest \
-              --title latest \
-              --notes "Latest schema release from $SOURCE_TAG."
-          else
-            gh release create latest \
-              dist/bigquery-json-schemas.zip \
-              --title latest \
-              --notes "Latest schema release from $SOURCE_TAG." \
-              --verify-tag
-          fi
+            --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,24 @@ jobs:
             --notes "Automated schema release for $RELEASE_TAG." \
             --verify-tag \
             "${release_flags[@]}"
+
+      - name: Publish latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_TAG: ${{ github.ref_name }}
+        run: |
+          git tag --force latest "$GITHUB_SHA"
+          git push --force origin refs/tags/latest
+
+          if gh release view latest >/dev/null 2>&1; then
+            gh release upload latest dist/bigquery-json-schemas.zip --clobber
+            gh release edit latest \
+              --title latest \
+              --notes "Latest schema release from $SOURCE_TAG."
+          else
+            gh release create latest \
+              dist/bigquery-json-schemas.zip \
+              --title latest \
+              --notes "Latest schema release from $SOURCE_TAG." \
+              --verify-tag
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release schemas
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create schema release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build schema archive
+        run: |
+          mkdir -p dist
+          zip -j dist/bigquery-json-schemas.zip ./*.json
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: schemas-${{ github.run_number }}.${{ github.run_attempt }}
+          RELEASE_TITLE: BigQuery schemas ${{ github.sha }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            dist/bigquery-json-schemas.zip \
+            --title "$RELEASE_TITLE" \
+            --notes "Automated schema release for $GITHUB_SHA." \
+            --target "$GITHUB_SHA"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release schemas
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -29,11 +29,16 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: schemas-${{ github.run_number }}.${{ github.run_attempt }}
-          RELEASE_TITLE: BigQuery schemas ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
+          release_flags=()
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            release_flags+=(--prerelease)
+          fi
+
           gh release create "$RELEASE_TAG" \
             dist/bigquery-json-schemas.zip \
-            --title "$RELEASE_TITLE" \
-            --notes "Automated schema release for $GITHUB_SHA." \
-            --target "$GITHUB_SHA"
+            --title "$RELEASE_TAG" \
+            --notes "Automated schema release for $RELEASE_TAG." \
+            --verify-tag \
+            "${release_flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: release-${{ github.ref }}
@@ -16,6 +15,8 @@ jobs:
   release:
     name: Create schema release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -50,32 +50,6 @@ If your dataset already exists and you only need to add a single table, run:
 bq mk --table YOUR_PROJECT_ID:matomo.log_visit log_visit.json
 ```
 
-## Load JSONL export data
-
-After the tables have been created, newline-delimited JSON export files can be loaded into the matching table:
-
-```bash
-bq load \
-  --source_format=NEWLINE_DELIMITED_JSON \
-  YOUR_PROJECT_ID:matomo.log_visit \
-  ./exports/log_visit.jsonl
-```
-
-For repeated loads, match the JSONL file to the table with the same base name:
-
-```bash
-PROJECT_ID="YOUR_PROJECT_ID"
-DATASET="matomo"
-EXPORT_DIR="./exports"
-
-for export_file in "${EXPORT_DIR}"/*.jsonl; do
-  table="$(basename "${export_file}" .jsonl)"
-  bq load \
-    --source_format=NEWLINE_DELIMITED_JSON \
-    "${PROJECT_ID}:${DATASET}.${table}" \
-    "${export_file}"
-done
-```
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,43 @@ If your dataset already exists and you only need to add a single table, run:
 ```bash
 bq mk --table YOUR_PROJECT_ID:matomo.log_visit log_visit.json
 ```
+
+## Load JSONL export data
+
+After the tables have been created, newline-delimited JSON export files can be loaded into the matching table:
+
+```bash
+bq load \
+  --source_format=NEWLINE_DELIMITED_JSON \
+  YOUR_PROJECT_ID:matomo.log_visit \
+  ./exports/log_visit.jsonl
+```
+
+For repeated loads, match the JSONL file to the table with the same base name:
+
+```bash
+PROJECT_ID="YOUR_PROJECT_ID"
+DATASET="matomo"
+EXPORT_DIR="./exports"
+
+for export_file in "${EXPORT_DIR}"/*.jsonl; do
+  table="$(basename "${export_file}" .jsonl)"
+  bq load \
+    --source_format=NEWLINE_DELIMITED_JSON \
+    "${PROJECT_ID}:${DATASET}.${table}" \
+    "${export_file}"
+done
+```
+
+## Releases
+
+Pushing a tag that starts with `v` creates a GitHub release containing `bigquery-json-schemas.zip`, an archive of all schema JSON files in this repository.
+
+For example:
+
+```bash
+git tag v0.0.0-test.1
+git push origin v0.0.0-test.1
+```
+
+Tags containing a hyphen, such as `v0.0.0-test.1`, are published as GitHub prereleases.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Matomo BigQuery schemas
+
+This repository contains JSON schema definitions for Matomo tables. The schemas are used to initialize Google BigQuery datasets that receive JSONL export data from the Matomo Data Warehouse Connector.
+
+Although these files are directly compatible with BigQuery schema JSON files, they are not intended to be limited to BigQuery. They can also be used as a structured reference for creating equivalent tables in other data warehouses.
+
+## Schema files
+
+Each `*.json` file represents one Matomo table. The filename without the `.json` extension is the expected table name.
+
+For example:
+
+- `log_visit.json` defines the `log_visit` table.
+- `log_link_visit_action.json` defines the `log_link_visit_action` table.
+- `site.json` defines the `site` table.
+
+## Initialize tables in BigQuery
+
+Install and authenticate the Google Cloud CLI, then select the project that should contain the Matomo export dataset:
+
+```bash
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+Create a BigQuery dataset:
+
+```bash
+bq mk --dataset --location=US YOUR_PROJECT_ID:matomo
+```
+
+Create one BigQuery table for each schema file:
+
+```bash
+PROJECT_ID="YOUR_PROJECT_ID"
+DATASET="matomo"
+
+for schema in *.json; do
+  table="${schema%.json}"
+  bq mk \
+    --table \
+    "${PROJECT_ID}:${DATASET}.${table}" \
+    "${schema}"
+done
+```
+
+If your dataset already exists and you only need to add a single table, run:
+
+```bash
+bq mk --table YOUR_PROJECT_ID:matomo.log_visit log_visit.json
+```


### PR DESCRIPTION
### Description:

  - Added a GitHub Actions release workflow for schema archives.
  - Releases are created when pushing tags matching v*, for example v0.0.0-test.1.
  - The workflow builds bigquery-json-schemas.zip from all root JSON schema files.
  - The release is explicitly marked as GitHub’s latest release with --latest.
  - Added a readme to the repo

  ## Website Download URL

  The latest schema archive can be linked from the website using:

  https://github.com/innocraft/bigquery-schema/releases/latest/download/bigquery-json-schemas.zip

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
