### PR TITLE
Add description to site schema

### DIFF
--- a/site.json
+++ b/site.json
@@ -10,6 +10,11 @@
     "mode": "NULLABLE"
   },
   {
+    "name": "description",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
     "name": "ecommerce",
     "type": "INTEGER",
     "mode": "NULLABLE"


### PR DESCRIPTION
### Description:
- Adds new `description` field to `site` schema.

Core update that introduced the change: https://github.com/innocraft/matomo-cloud/pull/4103